### PR TITLE
update-deploy-prod-namespace

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,3 +21,6 @@ jobs:
   deploy:
     uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.14
     secrets: inherit
+    with:
+      k8s-namespace: ${{ inputs.environment }}
+      k8s-release-name: ${{ inputs.environment }}

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -30,7 +30,7 @@ ingress:
 
 env:
   configmap:
-    DB_HOST: atla-omeka-production-mariadb
+    DB_HOST: omeka-production
     DB_NAME: omeka
     DB_PASSWORD: $DB_PASSWORD
     DB_PORT: 3306


### PR DESCRIPTION
Updates the deploy actions to use the production namespace which is just for tyhe time being till we transfer over to eks
