### PR TITLE
update-ingress-no-tls-no-nginx

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -19,14 +19,7 @@ php:
 ingress:
   enabled: true
   hosts:
-    - atla-omeka-production.notch8.cloud
     - dl.atla.com
-  annotations: {
-    kubernetes.io/ingress.class: "nginx",
-    nginx.ingress.kubernetes.io/proxy-body-size: "0",
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  }
-  tlsSecretName: atla-omeka-production-tls
 
 env:
   configmap:


### PR DESCRIPTION
The ingress does not need nginx, we do not use cert-manager and the tls is not needed