### PR TITLE
i330-add-tls-to-ingress

### DIFF
--- a/chart/templates/web-ing.yaml
+++ b/chart/templates/web-ing.yaml
@@ -32,11 +32,11 @@ spec:
         path: /exhibitions
         pathType: ImplementationSpecific
   {{- end }}
-  {{- if .Values.ingress.tlsSecretName }}
+  {{- if .Values.ingress.tls.secretName }}
   tls:
-  - secretName: {{ .Values.ingress.tlsSecretName }}
+  - secretName: {{ .Values.ingress.tls.secretName }}
     hosts:
-      {{- range .Values.ingress.hosts }}
+      {{- range .Values.ingress.tls.hosts }}
       - {{ . | quote }}
       {{- end }}
   {{- end }}

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -20,11 +20,14 @@ ingress:
   enabled: true
   hosts:
     - dl.atla.com
-    - atla.notch8.cloud
   annotations: {
     kubernetes.io/ingress.class: "nginx",
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   }
+  tls:
+    - hosts:
+        - dl.atla.com
+      secretName: notch8cloud
 
 env:
   configmap:


### PR DESCRIPTION
# Story
Updates the ingress to include the tls section
Updates the chart to use the correct mapping 
Remove the old unused atla.notch8.cloud dns

Refs #[330](https://github.com/scientist-softserv/atla_digital_library/issues/330)